### PR TITLE
Handle TaskFinished message idempotently.

### DIFF
--- a/src/core/src/test/scala/gwi/mawex/MawexSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/MawexSpec.scala
@@ -226,6 +226,12 @@ abstract class AbstractMawexSpec(_system: ActorSystem) extends TestKit(_system) 
       }
     }
 
+    "handle TaskFinished message idempotently" in {
+      val workerId = WorkerId(ConsumerGroup, "1", "1")
+      val taskId = TaskId("unknown", ConsumerGroup)
+      masterProxy ! w2m.TaskFinished(workerId, taskId, Right("ok"))
+      expectMsg(m2w.TaskResultAck(taskId))
+    }
   }
 }
 


### PR DESCRIPTION
If master actor is restarted either a TaskFinished message or TaskResultAck message can be lost and then a worker is stuck in infinite loop.