### PR TITLE
Checking for k8s job status

### DIFF
--- a/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
@@ -1,7 +1,7 @@
 package gwi.mawex.executor
 
 import java.io.ByteArrayInputStream
-
+import scala.concurrent.duration._
 import io.fabric8.kubernetes.client.{BatchAPIGroupClient, ConfigBuilder}
 import io.kubernetes.client.apis.BatchV1Api
 import io.kubernetes.client.util.Config
@@ -15,6 +15,8 @@ object K8 {
       "default",
       K8Resources("150m", "100Mi", "150m", "100Mi"),
       false,
+      1.minute,
+      1,
       "xxx", // cat ~/.kube/config | grep "server: "
       "xxx", // cat /run/secrets/kubernetes.io/serviceaccount/token
       "xxx" // new String(Base64.decodeBase64(cat /run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 -w 0)

--- a/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
@@ -31,7 +31,7 @@ class LocalMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: Ac
 
 class ForkedMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: ActorSystem) {
   def this() = this(ClusterService.buildClusterSystem(HostAddress("localhost", 0), List.empty, 1))
-  protected def executorProps(underlyingProps: Props): Props = SandBox.forkingProps(underlyingProps, ForkedJvmConf(System.getProperty("java.class.path")), ExecutorCmd(Some(jvmOpts)))
+  protected def executorProps(underlyingProps: Props): Props = SandBox.forkingProps(underlyingProps, ForkedJvmConf(System.getProperty("java.class.path"), 1.minute, 1), ExecutorCmd(Some(jvmOpts)))
   protected def singleMsgTimeout: FiniteDuration = 6.seconds
 }
 


### PR DESCRIPTION
Sometimes K8s jobs are not immediately scheduled for various reasons so the remote Executor ActorSystem is not started and doesn't register to Worker/Sandbox. This introduces periodic checking for Job status until the Job is running.