### PR TITLE
possibility to pass application.conf externally

### DIFF
--- a/src/core/src/main/resources/master.conf
+++ b/src/core/src/main/resources/master.conf
@@ -1,0 +1,17 @@
+akka {
+  actor.provider = "cluster"
+  cluster {
+    downing-provider-class = "tanukki.akka.cluster.autodown.OldestAutoDowning"
+    roles = ["backend"]
+  }
+  extensions = ["akka.cluster.client.ClusterClientReceptionist", "akka.cluster.pubsub.DistributedPubSub", "com.romix.akka.serialization.kryo.KryoSerializationExtension$"]
+  remote.netty.tcp.bind-hostname = "0.0.0.0"
+}
+custom-downing {
+  stable-after = 20s
+  shutdown-actor-system-on-resolution = true
+  oldest-auto-downing {
+    oldest-member-role = "backend"
+    down-if-alone = true
+  }
+}

--- a/src/core/src/main/resources/worker.conf
+++ b/src/core/src/main/resources/worker.conf
@@ -1,0 +1,7 @@
+akka {
+  actor.provider = "remote"
+  remote {
+    enabled-transports = ["akka.remote.netty.tcp"]
+    netty.tcp.bind-hostname = "0.0.0.0"
+  }
+}

--- a/src/core/src/main/scala/gwi/mawex/AkkaSupport.scala
+++ b/src/core/src/main/scala/gwi/mawex/AkkaSupport.scala
@@ -47,10 +47,12 @@ object RemoteService {
 protected[mawex] trait MountingService extends LazyLogging { this: Command =>
   var mountPath      = opt[Option[String]](useEnv = true, name="mount-path", description = "mount path to pass files to executor")
 
+  protected def getMountPath: Option[String] =
+    mountPath.map( path => if (path.endsWith("/")) path else path + "/" )
+
   protected def getAppConf: Option[File] = {
-    val appConfOpt = mountPath.map { path =>
-      val properPath = if (path.endsWith("/")) path else path + "/"
-      new File(s"${properPath}application.conf")
+    val appConfOpt = getMountPath.map { path =>
+      new File(s"${path}application.conf")
     }.filter(_.exists)
     appConfOpt.foreach(f => logger.debug(s"App configuration loaded from ${f.getAbsolutePath}") )
     appConfOpt

--- a/src/core/src/main/scala/gwi/mawex/executor/ExecutorSupervisor.scala
+++ b/src/core/src/main/scala/gwi/mawex/executor/ExecutorSupervisor.scala
@@ -102,7 +102,7 @@ class K8JobExecutorSupervisor(val executorConf: K8JobConf) extends ExecutorSuper
   override def receive: Receive = idle(0)
 
   def idle(attempts: Int): Receive = {
-    case s2es.Start(taskId, executorCmd) =>
+    case s2es.Start(taskId, executorCmd: K8sExecutorCmd) =>
       val jobName = JobName(taskId)
       val sandboxRef = sender()
       logger.debug(s"Starting k8s job $jobName")

--- a/src/core/src/main/scala/gwi/mawex/master/MasterCmd.scala
+++ b/src/core/src/main/scala/gwi/mawex/master/MasterCmd.scala
@@ -1,27 +1,22 @@
 package gwi.mawex.master
 
-import java.io.File
-
 import com.typesafe.scalalogging.LazyLogging
-import gwi.mawex.ClusterService
+import gwi.mawex.{ClusterService, MountingService}
 import org.backuity.clist.{Command, opt}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 
-object MasterCmd extends Command(name = "master", description = "launches master") with ClusterService with LazyLogging {
+object MasterCmd extends Command(name = "master", description = "launches master") with ClusterService with MountingService with LazyLogging {
   import ClusterService._
 
-  var appConfPath             = opt[String](name="app-conf-path", default = "etc/application.conf", description = "path of externally provided application.conf")
   var progressingTaskTimeout  = opt[Int](useEnv = true, default = 60*60, description = "timeout for a task progression in seconds")
   var pendingTaskTimeout      = opt[Int](useEnv = true, default = 3*24, description = "timeout for a pending task in hours")
   var masterId                = opt[String](useEnv = true, default = "master", name="master-id", description = "Unique identifier of this master node")
 
   def run(): Unit = {
-    val appConfPathOpt = Option(new File(appConfPath)).filter(_.exists)
     logger.info(s"Starting master $masterId hostAddress $hostAddress and seed nodes : ${seedNodes.mkString("\n","\n","\n")}")
-    appConfPathOpt.foreach( f => logger.info(s"App configuration loaded from ${f.getAbsolutePath}") )
-    val system = buildClusterSystem(hostAddress, seedNodes, seedNodes.size, appConfPathOpt)
+    val system = buildClusterSystem(hostAddress, seedNodes, seedNodes.size, getAppConf)
     clusterSingletonActorRef(Master.Config(masterId, progressingTaskTimeout.seconds, pendingTaskTimeout.hours), system)
     system.whenTerminated.onComplete(_ => System.exit(0))(ExecutionContext.Implicits.global)
     sys.addShutdownHook(Await.result(system.terminate(), 10.seconds))

--- a/src/core/src/main/scala/gwi/mawex/master/MasterCmd.scala
+++ b/src/core/src/main/scala/gwi/mawex/master/MasterCmd.scala
@@ -1,5 +1,7 @@
 package gwi.mawex.master
 
+import java.io.File
+
 import com.typesafe.scalalogging.LazyLogging
 import gwi.mawex.ClusterService
 import org.backuity.clist.{Command, opt}
@@ -10,13 +12,16 @@ import scala.concurrent.{Await, ExecutionContext}
 object MasterCmd extends Command(name = "master", description = "launches master") with ClusterService with LazyLogging {
   import ClusterService._
 
+  var appConfPath             = opt[String](name="app-conf-path", default = "etc/application.conf", description = "path of externally provided application.conf")
   var progressingTaskTimeout  = opt[Int](useEnv = true, default = 60*60, description = "timeout for a task progression in seconds")
   var pendingTaskTimeout      = opt[Int](useEnv = true, default = 3*24, description = "timeout for a pending task in hours")
   var masterId                = opt[String](useEnv = true, default = "master", name="master-id", description = "Unique identifier of this master node")
 
   def run(): Unit = {
+    val appConfPathOpt = Option(new File(appConfPath)).filter(_.exists)
     logger.info(s"Starting master $masterId hostAddress $hostAddress and seed nodes : ${seedNodes.mkString("\n","\n","\n")}")
-    val system = buildClusterSystem(hostAddress, seedNodes, seedNodes.size)
+    appConfPathOpt.foreach( f => logger.info(s"App configuration loaded from ${f.getAbsolutePath}") )
+    val system = buildClusterSystem(hostAddress, seedNodes, seedNodes.size, appConfPathOpt)
     clusterSingletonActorRef(Master.Config(masterId, progressingTaskTimeout.seconds, pendingTaskTimeout.hours), system)
     system.whenTerminated.onComplete(_ => System.exit(0))(ExecutionContext.Implicits.global)
     sys.addShutdownHook(Await.result(system.terminate(), 10.seconds))

--- a/src/core/src/main/scala/gwi/mawex/worker/WorkerCmd.scala
+++ b/src/core/src/main/scala/gwi/mawex/worker/WorkerCmd.scala
@@ -70,7 +70,7 @@ object WorkerCmd extends Command(name = "workers", description = "launches worke
       SandBox.forkingProps(
         executorProps,
         ForkedJvmConf(forkedJvmClassPath, sandboxCheckInterval.seconds, sandboxCheckLimit),
-        ExecutorCmd.forkedCmd(sandboxJvmOpts, mountPath)
+        ExecutorCmd.forkedCmd(sandboxJvmOpts, getMountPath)
       )
     case "k8s" =>
       logger.info(s"K8s mode enabled on worker")
@@ -78,7 +78,7 @@ object WorkerCmd extends Command(name = "workers", description = "launches worke
       SandBox.k8JobProps(
         executorProps,
         K8JobConf(k8Image, k8sNamespace, getExecutorResources, k8sClientDebugMode, sandboxCheckInterval.seconds, sandboxCheckLimit),
-        ExecutorCmd.k8sCmd(sandboxJvmOpts, mountPath, configMapName)
+        ExecutorCmd.k8sCmd(sandboxJvmOpts, getMountPath, configMapName)
       )
     case x =>
       throw new IllegalArgumentException(s"Executor type $x is not valid, please choose between local / forked / k8s")

--- a/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
@@ -37,7 +37,7 @@ class K8SandBoxSpec extends FreeSpecLike with K8BatchApiSupport with AkkaSupport
   private[this] implicit lazy val batchApi = new BatchV1Api(apiClient)
 
   "k8 client should succeed" in {
-    whenReady(runJob(JobName("job-test"), K8.conf, ExecutorCmd(List("df", "-h"), None))) { createResult =>
+    whenReady(runJob(JobName("job-test"), K8.conf, K8sExecutorCmd(List("df", "-h"), None, None, None))) { createResult =>
       Thread.sleep(3000)
       whenReady(deleteJob(JobName("job-test"), K8.conf)) { deleteResult =>
 
@@ -62,7 +62,7 @@ class Fabric8SandBoxSpec extends FreeSpecLike with Fabric8BatchApiSupport {
   implicit lazy val apiClient = new BatchAPIGroupClient(httpClient, config)
 
   "fabricate client should succeed" in {
-    println(runJob(JobName("job-test"), conf, ExecutorCmd(List("df", "-h"), None)))
+    println(runJob(JobName("job-test"), conf, K8sExecutorCmd(List("df", "-h"), None, None, None)))
 
     Thread.sleep(5000)
 

--- a/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.client.{BatchAPIGroupClient, ConfigBuilder}
 import io.kubernetes.client.apis.BatchV1Api
 import io.kubernetes.client.util.Config
 import okhttp3.OkHttpClient
+import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FreeSpecLike, Ignore}
 
 object K8 {
@@ -26,8 +27,8 @@ object K8 {
     )
 }
 
-@Ignore
 class K8SandBoxSpec extends FreeSpecLike with K8BatchApiSupport with AkkaSupport {
+  implicit lazy val futurePatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(300, Millis))
   private lazy val apiClient =
     Config.fromToken(
       K8.conf.serverApiUrl,

--- a/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/executor/K8SandBoxSpec.scala
@@ -27,6 +27,7 @@ object K8 {
     )
 }
 
+@Ignore
 class K8SandBoxSpec extends FreeSpecLike with K8BatchApiSupport with AkkaSupport {
   implicit lazy val futurePatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(300, Millis))
   private lazy val apiClient =

--- a/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
@@ -31,7 +31,7 @@ class LocalMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: Ac
 
 class ForkedMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: ActorSystem) {
   def this() = this(ClusterService.buildClusterSystem(HostAddress("localhost", 0), List.empty, 1, Option.empty))
-  protected def executorProps(underlyingProps: Props): Props = SandBox.forkingProps(underlyingProps, ForkedJvmConf(System.getProperty("java.class.path"), 60.minute, 1), ExecutorCmd(Some(jvmOpts)))
+  protected def executorProps(underlyingProps: Props): Props = SandBox.forkingProps(underlyingProps, ForkedJvmConf(System.getProperty("java.class.path"), 60.minute, 1), ExecutorCmd.forkedCmd(Some(jvmOpts), None))
   protected def singleMsgTimeout: FiniteDuration = 4.seconds
 }
 

--- a/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success, Try}
 class LocalMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: ActorSystem) {
   def this() = this(ClusterService.buildClusterSystem(HostAddress("localhost", 0), List.empty, 1, Option.empty))
   protected def executorProps(underlyingProps: Props): Props = SandBox.localJvmProps(underlyingProps)
-  protected def singleMsgTimeout: FiniteDuration = 1.second
+  protected def singleMsgTimeout: FiniteDuration = 2.second
 }
 
 class ForkedMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: ActorSystem) {

--- a/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
+++ b/src/core/src/test/scala/gwi/mawex/master/MawexSpec.scala
@@ -24,13 +24,13 @@ import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
 class LocalMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: ActorSystem) {
-  def this() = this(ClusterService.buildClusterSystem(HostAddress("localhost", 0), List.empty, 1))
+  def this() = this(ClusterService.buildClusterSystem(HostAddress("localhost", 0), List.empty, 1, Option.empty))
   protected def executorProps(underlyingProps: Props): Props = SandBox.localJvmProps(underlyingProps)
   protected def singleMsgTimeout: FiniteDuration = 1.second
 }
 
 class ForkedMawexSpec(_system: ActorSystem) extends AbstractMawexSpec(_system: ActorSystem) {
-  def this() = this(ClusterService.buildClusterSystem(HostAddress("localhost", 0), List.empty, 1))
+  def this() = this(ClusterService.buildClusterSystem(HostAddress("localhost", 0), List.empty, 1, Option.empty))
   protected def executorProps(underlyingProps: Props): Props = SandBox.forkingProps(underlyingProps, ForkedJvmConf(System.getProperty("java.class.path"), 60.minute, 1), ExecutorCmd(Some(jvmOpts)))
   protected def singleMsgTimeout: FiniteDuration = 4.seconds
 }


### PR DESCRIPTION
The desired behavior is having a k8s ConfigMap with `application.conf` mounted to docker containers and not having to redeploy applications when conf changes, just upgrading cluster.

This would work except for the `k8s` executor type where another change is required to actually mount that file from `ConfigMap` into a k8s Job.